### PR TITLE
Enhance generator and GUI with high‑res presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The project is still under development, but a typical command to generate a map 
 python map_generator.py --width 1200 --height 800 --output sample_map.png
 ```
 
+You can also use resolution presets (1080p, 4k, 8k) or generate districts:
+
+```bash
+python map_generator.py --preset 4k --districts 3 --output big_map.png
+```
+
 This would produce a map saved as `sample_map.png` in the current directory.
 
 ## Generating a Sample Map
@@ -57,6 +63,6 @@ An experimental GUI editor is available for interactive map creation. Launch it 
 python gui_editor.py --width 1200 --height 800
 ```
 
-Use the toolbar on the right to choose between buildings, roads, rivers, and districts. Click and drag on the canvas to place elements. Press **Save** to export your map to a PNG file.
+Use the toolbar on the right to choose between buildings, roads, rivers, and districts. A drop-down lets you pick a resolution preset and how many districts to generate. Press **Generate Map** to fill the canvas automatically, then refine the result manually. Press **Save** to export your map to a PNG file.
 
 

--- a/gui_editor.py
+++ b/gui_editor.py
@@ -18,6 +18,16 @@ class MapEditor(tk.Tk):
         self.toolbar = ttk.Frame(self)
         self.toolbar.pack(side=tk.RIGHT, fill=tk.Y)
 
+        ttk.Label(self.toolbar, text="Resolution").pack()
+        self.res_var = tk.StringVar(value="Custom")
+        presets = ["Custom"] + list(mg.RESOLUTION_PRESETS.keys())
+        self.res_menu = ttk.OptionMenu(self.toolbar, self.res_var, self.res_var.get(), *presets, command=self.on_resolution_select)
+        self.res_menu.pack(fill=tk.X)
+
+        ttk.Label(self.toolbar, text="Districts").pack(pady=(5, 0))
+        self.district_var = tk.IntVar(value=0)
+        ttk.Spinbox(self.toolbar, from_=0, to=20, textvariable=self.district_var, width=5).pack(fill=tk.X)
+
         self.element = tk.StringVar(value="rectangle")
         options = [
             ("Rectangle Building", "rectangle"),
@@ -31,6 +41,7 @@ class MapEditor(tk.Tk):
         ]
         for text, value in options:
             ttk.Radiobutton(self.toolbar, text=text, variable=self.element, value=value).pack(anchor=tk.W)
+        ttk.Button(self.toolbar, text="Generate Map", command=self.generate_map).pack(fill=tk.X, pady=5)
         ttk.Button(self.toolbar, text="Save", command=self.save_image).pack(fill=tk.X, pady=10)
 
         self.shapes = []
@@ -41,6 +52,15 @@ class MapEditor(tk.Tk):
         self.canvas.bind("<ButtonPress-1>", self.on_press)
         self.canvas.bind("<B1-Motion>", self.on_drag)
         self.canvas.bind("<ButtonRelease-1>", self.on_release)
+
+    def on_resolution_select(self, value):
+        if value in mg.RESOLUTION_PRESETS:
+            w, h = mg.RESOLUTION_PRESETS[value]
+            if mg.validate_resolution(w, h):
+                self.width = w
+                self.height = h
+                self.canvas.config(width=w, height=h)
+        self.res_var.set(value)
 
     def on_press(self, event):
         self.start_x = event.x
@@ -102,11 +122,42 @@ class MapEditor(tk.Tk):
                     mg.draw_polygon(draw, poly)
         img.save(path)
 
+    def generate_map(self):
+        self.canvas.delete("all")
+        self.shapes.clear()
+        data = mg.generate_map_data(
+            self.width,
+            self.height,
+            num_shapes=10,
+            num_districts=self.district_var.get(),
+        )
+        for box in data["districts"]:
+            self.canvas.create_rectangle(box, outline="gray", width=2)
+            self.shapes.append(("district", box))
+        for shape_type, shape_data in data["buildings"]:
+            if shape_type == "polygon":
+                self.canvas.create_polygon(shape_data, fill=mg.SHAPE_COLOR)
+                self.shapes.append(("polygon", shape_data))
+            else:
+                if shape_type == "l":
+                    box = shape_data
+                else:
+                    box = shape_data
+                self.canvas.create_rectangle(box, outline=mg.SHAPE_COLOR)
+                self.shapes.append((shape_type, box))
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Launch the map editor")
     parser.add_argument("--width", type=int, default=mg.DEFAULT_WIDTH, help="canvas width")
     parser.add_argument("--height", type=int, default=mg.DEFAULT_HEIGHT, help="canvas height")
+    parser.add_argument("--preset", choices=["1080p", "4k", "8k"], help="resolution preset")
     args = parser.parse_args()
+
+    if args.preset:
+        args.width, args.height = mg.RESOLUTION_PRESETS[args.preset]
+    if not mg.validate_resolution(args.width, args.height):
+        parser.error(f"Resolution must be within 1x1 and {mg.MAX_WIDTH}x{mg.MAX_HEIGHT}")
+
     app = MapEditor(width=args.width, height=args.height)
     app.mainloop()

--- a/map_generator.py
+++ b/map_generator.py
@@ -5,6 +5,14 @@ from PIL import Image, ImageDraw
 # Default canvas size. These values can be overridden via command line
 # arguments or when calling the drawing functions directly.
 DEFAULT_WIDTH, DEFAULT_HEIGHT = 800, 600
+MAX_WIDTH, MAX_HEIGHT = 8192, 8192
+
+RESOLUTION_PRESETS = {
+    "1080p": (1920, 1080),
+    "4k": (3840, 2160),
+    "8k": (7680, 4320),
+}
+
 BG_COLOR = "white"
 SHAPE_COLOR = "black"
 
@@ -13,6 +21,11 @@ def intersects(a, b):
     ax1, ay1, ax2, ay2 = a
     bx1, by1, bx2, by2 = b
     return not (ax2 <= bx1 or ax1 >= bx2 or ay2 <= by1 or ay1 >= by2)
+
+
+def validate_resolution(width, height):
+    """Return True if width and height are within supported range."""
+    return 1 <= width <= MAX_WIDTH and 1 <= height <= MAX_HEIGHT
 
 
 def generate_buildings(width, height, num_shapes=10, max_attempts=1000):
@@ -67,20 +80,39 @@ def random_polygon_from_box(box, min_vertices=3, max_vertices=6):
     return points
 
 
-def generate_map_data(width, height, num_shapes=10):
+def generate_districts(width, height, count, max_attempts=1000):
+    """Generate rectangular district areas that do not overlap."""
+    districts = []
+    boxes = []
+    attempts = 0
+    while len(districts) < count and attempts < max_attempts:
+        w = random.randint(width // 6, width // 2)
+        h = random.randint(height // 6, height // 2)
+        x = random.randint(0, width - w)
+        y = random.randint(0, height - h)
+        box = (x, y, x + w, y + h)
+        if any(intersects(box, b) for b in boxes):
+            attempts += 1
+            continue
+        boxes.append(box)
+        districts.append(box)
+    return districts
+
+
+def generate_map_data(width, height, num_shapes=10, num_districts=0):
     return {
         "buildings": generate_buildings(width, height, num_shapes),
         "roads": [],
         "rivers": [],
-        "districts": [],
+        "districts": generate_districts(width, height, num_districts) if num_districts > 0 else [],
         "walls": [],
     }
 
 
-def draw_map(filename="map.png", width=DEFAULT_WIDTH, height=DEFAULT_HEIGHT, num_shapes=10):
+def draw_map(filename="map.png", width=DEFAULT_WIDTH, height=DEFAULT_HEIGHT, num_shapes=10, num_districts=0):
     img = Image.new("RGB", (width, height), BG_COLOR)
     draw = ImageDraw.Draw(img)
-    data = generate_map_data(width, height, num_shapes)
+    data = generate_map_data(width, height, num_shapes, num_districts)
     for shape_type, shape_data in data["buildings"]:
         if shape_type == "l":
             draw_l_shape(draw, shape_data)
@@ -88,6 +120,8 @@ def draw_map(filename="map.png", width=DEFAULT_WIDTH, height=DEFAULT_HEIGHT, num
             draw_polygon(draw, shape_data)
         else:
             draw.rectangle(shape_data, fill=SHAPE_COLOR)
+    for box in data["districts"]:
+        draw.rectangle(box, outline="gray", width=2)
     img.save(filename)
     print(f"Map saved to {filename}")
 
@@ -96,7 +130,21 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate a procedural map")
     parser.add_argument("--width", type=int, default=DEFAULT_WIDTH, help="map width")
     parser.add_argument("--height", type=int, default=DEFAULT_HEIGHT, help="map height")
+    parser.add_argument("--preset", choices=sorted(RESOLUTION_PRESETS.keys()), help="use a resolution preset")
     parser.add_argument("--num-shapes", type=int, default=10, help="number of buildings")
+    parser.add_argument("--districts", type=int, default=0, help="number of districts to generate")
     parser.add_argument("--output", type=str, default="map.png", help="output image path")
     args = parser.parse_args()
-    draw_map(filename=args.output, width=args.width, height=args.height, num_shapes=args.num_shapes)
+
+    if args.preset:
+        args.width, args.height = RESOLUTION_PRESETS[args.preset]
+    if not validate_resolution(args.width, args.height):
+        parser.error(f"Resolution must be within 1x1 and {MAX_WIDTH}x{MAX_HEIGHT}")
+
+    draw_map(
+        filename=args.output,
+        width=args.width,
+        height=args.height,
+        num_shapes=args.num_shapes,
+        num_districts=args.districts,
+    )


### PR DESCRIPTION
## Summary
- support high-res presets, validation, and districts in map_generator
- enable automatic map generation in the GUI
- add options for resolution presets and district count in the GUI
- document new features in README

## Testing
- `python -m py_compile map_generator.py gui_editor.py`
- `python map_generator.py --preset 1080p --districts 1 --num-shapes 3 --output test.png && ls -l test.png`


------
https://chatgpt.com/codex/tasks/task_e_6868a5e33d5083289a7d29fa052b0936